### PR TITLE
[WIP] Increase test coverage

### DIFF
--- a/clockifyclient/models.py
+++ b/clockifyclient/models.py
@@ -164,7 +164,6 @@ class APIObject:
         """
         return cls(
             obj_id=cls.get_item(dict_in=dict_in, key="id"),
-            name=cls.get_item(dict_in=dict_in, key="name"),
         )
 
 

--- a/tests/mock_responses.py
+++ b/tests/mock_responses.py
@@ -82,3 +82,13 @@ POST_TIME_ENTRY = RequestMockResponse(
  """,
     201,
 )
+
+# calling post '/workspaces/<workspace id>/time-entries' (no project, no task)
+POST_TIME_ENTRY_NO_PROJECT_NO_TASK = RequestMockResponse(
+    """{"id": "123456", "description": "testing description", "tagIds": null,
+ "userId": "123456", "billable": false, "taskId": null, "projectId": null,
+ "timeInterval": {"start": "2019-10-23T17:18:58Z", "end": "2019-10-23T18:18:58Z", "duration": "PT1H"},
+ "workspaceId": "123456", "isLocked": false}
+ """,
+    201,
+)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,6 +59,8 @@ def test_date_conversion(mock_models_timezone):
 
     # str representation should always be UTC in Clockify format, ending in Z (for UTC)
     assert str(ClockifyDatetime(datetime)) == "2018-06-12T14:01:41Z"
+    # datetime_local should have been branded with local (mock +8)
+    assert str(ClockifyDatetime(datetime).datetime_local) == "2018-06-12 22:01:41+08:00"
     # Naive datetime should have been branded with local (mock +8)
     assert (
         str(ClockifyDatetime.init_from_string("2018-06-12T14:01:41"))
@@ -71,7 +73,6 @@ def test_date_conversion(mock_models_timezone):
     )
     # but the normal datetime should be unaffected: should be as input
     assert ClockifyDatetime.init_from_string("2018-06-12T14:01:41").datetime.hour == 14
-
     cltime = ClockifyDatetime(datetime)
     ClockifyDatetime.init_from_string(str(cltime))
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,7 @@ from clockifyclient.models import (
     NamedAPIObject,
     ClockifyDatetime,
 )
-from tests.mock_responses import POST_TIME_ENTRY
+from tests.mock_responses import POST_TIME_ENTRY, POST_TIME_ENTRY_NO_PROJECT_NO_TASK
 
 
 @pytest.fixture()
@@ -30,6 +30,11 @@ def mock_models_timezone(monkeypatch):
     )
 
 
+def test_apiobject():
+    time_entry_dict = json.loads(POST_TIME_ENTRY.text)
+    api_object = APIObject.init_from_dict(time_entry_dict)
+    assert api_object.obj_id == "123456"
+
 def test_time_entry_from_dict(mock_models_timezone):
     time_entry_dict = json.loads(POST_TIME_ENTRY.text)
     time_entry = TimeEntry.init_from_dict(time_entry_dict)
@@ -40,6 +45,16 @@ def test_time_entry_from_dict(mock_models_timezone):
     assert time_entry_dict_again["description"] == "testing description"
     assert time_entry_dict_again["projectId"] == "123456"
     assert time_entry_dict_again["taskId"] == "123456"
+
+
+def test_time_entry_no_project_no_task(mock_models_timezone):
+    time_entry_dict = json.loads(POST_TIME_ENTRY_NO_PROJECT_NO_TASK.text)
+    time_entry = TimeEntry.init_from_dict(time_entry_dict)
+    assert time_entry.project == None
+    assert time_entry.task == None
+
+    time_entry_dict_again = TimeEntry.to_dict(time_entry)
+    assert time_entry_dict_again["end"] == "2019-10-23T18:18:58Z"
 
 
 def test_time_entry(a_date):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,7 @@ from clockifyclient.models import (
     Task,
     TaskStub,
     TimeEntry,
+    TimeEntryQuery,
     User,
     Project,
     Workspace,
@@ -87,8 +88,8 @@ def test_str(a_date):
     str(Workspace(obj_id="123", name="test"))
     str(APIObject(obj_id="123"))
     str(NamedAPIObject(obj_id="123", name="test"))
-
     str(TimeEntry(obj_id="123", start=a_date))
+    str(TimeEntryQuery(description="test"))
 
 
 def test_truncate(a_date):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,6 +17,7 @@ from clockifyclient.models import (
     ProjectStub,
     NamedAPIObject,
     ClockifyDatetime,
+    ObjectParseException
 )
 from tests.mock_responses import POST_TIME_ENTRY, POST_TIME_ENTRY_NO_PROJECT_NO_TASK
 
@@ -34,6 +35,20 @@ def test_apiobject():
     time_entry_dict = json.loads(POST_TIME_ENTRY.text)
     api_object = APIObject.init_from_dict(time_entry_dict)
     assert api_object.obj_id == "123456"
+
+    with pytest.raises(ObjectParseException):
+        api_object.get_item(time_entry_dict, "not_a_key")
+    
+    assert api_object.get_item(time_entry_dict, "not_a_key", None) == None
+
+    with pytest.raises(ObjectParseException):
+        time_entry_dict['empty_date'] = None
+        api_object.get_datetime(time_entry_dict, "empty_date")
+
+    with pytest.raises(ObjectParseException):
+        time_entry_dict['bad_date'] = "2019-1023T18:18:A"
+        api_object.get_datetime(time_entry_dict, "bad_date")
+
 
 def test_time_entry_from_dict(mock_models_timezone):
     time_entry_dict = json.loads(POST_TIME_ENTRY.text)


### PR DESCRIPTION
@sjoerdk I've wanted to increase the overall test code coverage before implementing new features but I haven't worked with tests before. I've tried to create some more tests and wanted to check with you if it's okay.

I think there was a slight bug in the APIObject's [`init_from_dict()` method](https://github.com/sjoerdk/clockifyclient/blob/master/clockifyclient/models.py#L146). It was initializing a new APIObject with a not-defined parameter (`name`). I assumed that the `APIObject` class was not supposed to have that variable, so I removed it from the object creation in the `init_from_dict()` method.

[Link ](https://codecov.io/gh/lukasab/clockifyclient/tree/e1bf6acaffd7979c4ef80055c6247f8d7217f998/clockifyclient) for the codecov coverage report.